### PR TITLE
feat: use gvm to install Go

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-go_version: "1.17.3"
+go_version: "1.17.8"
 go_platform: linux
 go_arch: amd64
 go_tarball: go{{ go_version }}.{{ go_platform }}-{{ go_arch }}.tar.gz

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,6 @@ go_arch: amd64
 go_tarball: go{{ go_version }}.{{ go_platform }}-{{ go_arch }}.tar.gz
 go_download_url: https://dl.google.com/go/{{ go_tarball }}
 go_checksum: '550f9845451c0c94be679faf116291e7807a8d78b43149f9506c1b15eb89008c'
+
+gvm_version: "0.4.1"
+gvm_download_url: https://github.com/andrewkroh/gvm/releases/download/v{{ gvm_version }}/gvm-{{ gvm_platform }}-{{ gvm_arch }}

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -20,6 +20,9 @@
 
   tasks:
     - name: Verify that Go is installed and available in the $PATH.
+      shell: eval $(gvm {{ go_version }})
+
+    - name: Verify that Go is installed and available in the $PATH.
       command: go version
       environment:
         GORROT: ~/.gvm/versions/go{{ go_version }}.{{ gvm_platform }}.{{ gvm_arch }}

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -22,5 +22,6 @@
     - name: Verify that Go is installed and available in the $PATH.
       command: go version
       environment:
-        PATH: /usr/local/go/bin:{{ ansible_env.PATH }}
+        GORROT: ~/.gvm/versions/go{{ go_version }}.{{ gvm_platform }}.{{ gvm_arch }}
+        PATH: ~/.gvm/versions/go{{ go_version }}.{{ gvm_platform }}.{{ gvm_arch }}/bin:{{ ansible_env.PATH }}
       changed_when: false

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -20,11 +20,5 @@
 
   tasks:
     - name: Verify that Go is installed and available in the $PATH.
-      shell: eval $(gvm {{ go_version }})
-
-    - name: Verify that Go is installed and available in the $PATH.
-      command: go version
-      environment:
-        GORROT: ~/.gvm/versions/go{{ go_version }}.{{ gvm_platform }}.{{ gvm_arch }}
-        PATH: ~/.gvm/versions/go{{ go_version }}.{{ gvm_platform }}.{{ gvm_arch }}/bin:{{ ansible_env.PATH }}
+      shell: eval $(gvm {{ go_version }}) && go version
       changed_when: false

--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -1,12 +1,12 @@
 ---
 - name: Check if Go is already installed.
-  command: go version
+  command: 'go version'
   ignore_errors: true
   register: go_version_result
   changed_when: false
 
 - name: Check if gvm is already installed.
-  command: ~/bin/gvm version
+  command: '/usr/local/bin/gvm version'
   ignore_errors: true
   register: gvm_version_result
   changed_when: false
@@ -14,7 +14,7 @@
 - name: Download gvm.
   get_url:
     url: "{{ gvm_download_url }}"
-    dest: ~/bin/gvm
+    dest: '/usr/local/bin/gvm'
     mode: '0755'
   when:
     - go_version_result is failed

--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -1,26 +1,27 @@
 ---
 - name: Check if Go is already installed.
-  command: /usr/local/go/bin/go version
+  command: go version
   ignore_errors: true
   register: go_version_result
   changed_when: false
 
-- name: Download Go.
+- name: Check if gvm is already installed.
+  command: ~/bin/gvm version
+  ignore_errors: true
+  register: gvm_version_result
+  changed_when: false
+
+- name: Download gvm.
   get_url:
-    url: "{{ go_download_url }}"
-    dest: /usr/local/src/{{ go_tarball }}
-    checksum: "sha256:{{ go_checksum }}"
-  when: go_version_result is failed
+    url: "{{ gvm_download_url }}"
+    dest: ~/bin/gvm
+    mode: '0755'
+  when:
+    - go_version_result is failed
+    - gvm_version_result is failed
 
-- name: Extract Go.
-  unarchive:
-    src: /usr/local/src/{{ go_tarball }}
-    dest: /usr/local
-    copy: false
-  when: go_version_result is failed
-
-- name: Add Go to to system-wide $PATH.
-  copy:
-    dest: /etc/profile.d/go-path.sh
-    content: |-
-      export PATH=$PATH:/usr/local/go/bin
+- name: Install Go.
+  shell: eval $(gvm {{ go_version }})
+  when:
+    - go_version_result is failed
+    - gvm_version_result is failed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,15 @@
 ---
+- name: Load a variable file based on the OS type, or a default if not found.
+  include_vars: "{{ lookup('first_found', params) }}"
+  vars:
+    params:
+      files:
+        - '{{ ansible_distribution }}.yml'
+        - '{{ ansible_os_family }}.yml'
+        - default.yml
+      paths:
+        - 'vars'
+
 - name: Install Go for Linux
   import_tasks: linux.yml
   when: ansible_facts['os_family']|lower in ['redhat', 'debian', 'suse']

--- a/vars/Darwin.yml
+++ b/vars/Darwin.yml
@@ -1,0 +1,3 @@
+---
+gvm_platform: darwin
+gvm_arch: amd64

--- a/vars/Windows.yml
+++ b/vars/Windows.yml
@@ -1,0 +1,4 @@
+---
+gvm_platform: windows
+gvm_arch: amd64
+gvm_download_url: https://github.com/andrewkroh/gvm/releases/download/v{{ gvm_version }}/gvm-{{ gvm_platform }}-{{ gvm_arch }}.exe

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,0 +1,3 @@
+---
+gvm_platform: linux
+gvm_arch: amd64


### PR DESCRIPTION
- chore: bump Go to 1.17.8
- chore: load custom variables per OS
- chore: install Go using gvm on Linux

## What does this PR do?
It uses gvm to install Go: https://github.com/andrewkroh/gvm

